### PR TITLE
Explicit timestamps

### DIFF
--- a/bin/osm-fetch.js
+++ b/bin/osm-fetch.js
@@ -2,52 +2,55 @@
 
 var fetch = require('..');
 var args = require('minimist')(process.argv.slice(2), {
-  boolean: ['s', 'shallow', 'c', 'creation', 'v', 'verbose']
+  boolean: ['s', 'shallow']
 });
 
 var baseUrl = 'https://www.openstreetmap.org';
 
 if (args.help || !args._[0] || !args._[1]) {
-  console.log('Usage: osm-fetch [OPTIONS] <type> <id> [version]');
+  console.log('Usage: osm-fetch [OPTIONS] <type> <id>');
   console.log('');
   console.log('Options:');
+  console.log(' -v, --version\tFetch the specified version of the feature');
+  console.log(' -t, --timestamp\tFind references that existed at the requested time (in ms).');
   console.log(' -s, --shallow\tFetch XML for the most recent version and do not resolve member relations');
-  console.log(' -c, --creation\tFind references that existed at the requested feature\'s creation time.');
-  console.log('               \tDefault behavior without this flag is to find references that existed');
-  console.log('               \timmediately prior to the creation of a new version, or in other words,');
-  console.log('               \tthe final state of the requested version of the feature');
-  console.log(' -v, --verbose\tPrint a timestamp for the data returned');
   console.log('');
   console.log('Examples:');
-  console.log('  $ osm-fetch relation 2453564 1');
-  console.log('  $ osm-fetch relation 2453564 --shallow');
-  console.log('  $ osm-fetch relation 2453564 1 --creation');
+  console.log('# Fetch the most recent version of relation 2453564');
+  console.log('$ osm-fetch relation 2453564');
+  console.log('');
+  console.log('# Fetch version 1 of relation 2453564');
+  console.log('$ osm-fetch relation 2453564 --version 1');
+  console.log('');
+  console.log('# Fetch relation 2453564 at 2012-10-05T04:00:00Z');
+  console.log('$ osm-fetch relation 2453564 --timestamp 1349409600000');
+  console.log('');
+  console.log('# Shallow fetch of the most recent version of relation 2453564');
+  console.log('$ osm-fetch relation 2453564 --shallow');
   console.log('');
   process.exit();
 }
 
-if ((args.s || args.shallow) && (args.c || args.creation)) {
-  console.error(new Error('--shallow and --creation flags are incompatible'));
+if ((args.s || args.shallow) && (args.t || args.timestamp)) {
+  console.error(new Error('--shallow and --timestamp flags are incompatible'));
   process.exit(1);
 }
 
 if (args.s || args.shallow)
   return fetch.shallow(baseUrl, args._[0], args._[1], got);
 
-var options = {
-  version: args._[2],
-  creationTime: args.c || args.creation
-};
+var timestamp = args.t || args.timestamp;
+var version = args.v || args.version;
+if (version) version = Number(version);
 
-fetch.full(baseUrl, args._[0], args._[1], options, got);
+if (timestamp) fetch.at(baseUrl, args._[0], Number(args._[1]), Number(timestamp), got);
+else fetch.full(baseUrl, args._[0], args._[1], version, got);
 
-function got(err, xmls, timestamp) {
+function got(err, xmls) {
   if (err) {
     console.error(err);
     process.exit(1);
   }
-
-  if (args.v || args.verbose) console.error('Fetched data for %s', (new Date(timestamp).toISOString()));
 
   console.log(xmls);
 }

--- a/index.js
+++ b/index.js
@@ -5,78 +5,82 @@ var async = require('queue-async');
 
 module.exports.full = full;
 module.exports.shallow = shallow;
+module.exports.at = at;
 
 function shallow(baseUrl, type, id, callback) {
   var client = osm(baseUrl);
   client.fetchShallow(type, id, callback);
 }
 
-function full(baseUrl, type, id, options, callback) {
+function at(baseUrl, type, id, timestamp, callback) {
   var client = osm(baseUrl);
 
-  if (typeof options === 'function') {
-    callback = options;
-    options = {};
-  }
+  client.fetchVersionAt(type, id, timestamp, function(err, parent) {
+    if (err) return callback(err);
+    getRefs(client, parent, timestamp, callback);
+  });
+}
 
-  var version = options.version;
-  var creationTime = options.creationTime;
+function full(baseUrl, type, id, version, callback) {
+  var client = osm(baseUrl);
+
+  if (typeof version === 'function') {
+    callback = version;
+    version = null;
+  }
 
   client.fetch(type, id, version, function(err, parent) {
     if (err) return callback(err);
-    var xmls = [parent];
-    var timestamp;
+    getRefs(client, parent, null, callback);
+  });
+}
 
-    function fetchRefs(element, callback) {
-      var queue = async();
+function getRefs(client, parent, timestamp, callback) {
+  var xmls = [parent];
 
-      element.refs.forEach(function(ref) {
-        queue.defer(function(next) {
-          client.fetchVersionAt(ref.type, ref.id, timestamp, function(err, xml) {
-            if (err) return next(err);
+  function fetchRefs(element, callback) {
+    var queue = async();
 
-            xmls.push(xml);
+    element.refs.forEach(function(ref) {
+      queue.defer(function(next) {
+        client.fetchVersionAt(ref.type, ref.id, timestamp, function(err, xml) {
+          if (err) return next(err);
 
-            parse(xml, function(err, elements) {
-              if (err) {
-                err.statusCode = 500;
-                return next(err);
-              }
+          xmls.push(xml);
 
-              fetchRefs(elements[0], next);
-            });
+          parse(xml, function(err, elements) {
+            if (err) {
+              err.statusCode = 500;
+              return next(err);
+            }
+
+            fetchRefs(elements[0], next);
           });
         });
       });
+    });
 
-      queue.awaitAll(callback);
+    queue.awaitAll(callback);
+  }
+
+  function allDone(err) {
+    if (err) return callback(err);
+    aggregate(xmls, function(err, result) {
+      callback(err, result, timestamp);
+    });
+  }
+
+  parse(parent, function(err, elements) {
+    if (err) {
+      err.statusCode = 500;
+      return callback(err);
     }
 
-    function allDone(err) {
+    if (timestamp) return fetchRefs(elements[0], allDone);
+    client.finalTimestamp(elements[0].type, Number(elements[0].id), Number(elements[0].version), function(err, finalTimestamp) {
       if (err) return callback(err);
-      aggregate(xmls, function(err, result) {
-        callback(err, result, timestamp);
-      });
-    }
-
-    parse(parent, function(err, elements) {
-      if (err) {
-        err.statusCode = 500;
-        return callback(err);
-      }
-
-      if (!version) version = elements[0].version;
-
-      if (creationTime) {
-        timestamp = +new Date(elements[0].timestamp);
-        fetchRefs(elements[0], allDone);
-      } else {
-        client.finalTimestamp(type, id, version, function(err, finalTimestamp) {
-          if (err) return callback(err);
-          timestamp = finalTimestamp;
-          fetchRefs(elements[0], allDone);
-        });
-      }
+      timestamp = finalTimestamp;
+      fetchRefs(elements[0], allDone);
     });
   });
 }

--- a/readme.md
+++ b/readme.md
@@ -21,55 +21,21 @@ Usage: osm-fetch [OPTIONS] <type> <id> [version]
 
 Options:
  -s, --shallow	Fetch XML for the most recent version and do not resolve member relations
- -c, --creation	Find references that existed at the requested feature's creation time.
-               	Default behavior without this flag is to find references that existed
-               	immediately prior to the creation of a new version, or in other words,
-               	the final state of the requested version of the feature
- -v, --verbose	Print a timestamp for the data returned
+ -t, --timestamp	Find references that existed at the requested time (in ms).
 
 Examples:
-  $ osm-fetch relation 2453564 1
+  # Fetch the most recent version of relation 2453564
+  $ osm-fetch relation 2453564
+
+  # Fetch version 1 of relation 2453564
+  $ osm-fetch relation 2453564 --version 1
+
+  # Fetch relation 2453564 at 2012-10-05T04:00:00Z
+  $ osm-fetch relation 2453564 --timestamp 1349409600000
+
+  # Shallow fetch of the most recent version of relation 2453564
   $ osm-fetch relation 2453564 --shallow
-  $ osm-fetch relation 2453564 1 --creation
 ```
-
-## Understanding timestamps
-
-The default behavior is to fetch the **final** state of a particular version. If
-the requested version is the most recent for the feature, then the most current
-versions of references will be included in the response. However if there is a
-more recent version, then the response will include the state of all references
-that existed **just prior** to the creation of the new version.
-
-You can choose an alternative behavior by setting the `--creation` flag. With this
-flag set, the response will include the state of references at the **creation**
-time for the requested version.
-
-To understand these distinctions, consider the following scenario:
-
-- way 1234 includes nodes 1, 2, and 3
-- way 1234 v2 is created at 2016-02-14T00:00:00Z
-- at this time, the nodes are all v1
-- nodes 2 and 3 are updated to v2 and twice to v3, respectively
-- way 1234 is updated to v3 at 2016-02-14T02:00:00Z
-
-When requesting way 1234 v2 via `osm-fetch`, the default behavior will
-return the **final** state of the way, _just prior_ to 2016-02-14T02:00:00Z,
-that is:
-- way 1234 v2
-- node 1 v1
-- node 2 v2
-- node 3 v3
-
-By specifying the `--creation` flag, you'll receive data as it existed at the
-**creation** time for v2, that is, at 2016-02-14T00:00:00Z. You'll receive:
-- way 1234 v2
-- node 1 v1
-- node 2 v1
-- node 3 v1
-
-If you're curious, specifying the `--verbose` flag will print the timestamp that
-the response data represents to stderr.
 
 ## Shallow mode
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,129 +1,40 @@
 var mockOsm = require('./mock-osm');
 var full = require('..').full;
 var shallow = require('..').shallow;
+var at = require('..').at;
 var fs = require('fs');
 var path = require('path');
 
-mockOsm.test('[index.full] (creationTime) gets all xml', function(assert) {
-  full(mockOsm.baseUrl, 'relation', 2453564, { version: 1, creationTime: true }, function(err, xml, timestamp) {
-    assert.ifError(err, 'success');
-    assert.equal(timestamp, 1349406008000, 'expected timestamp');
-    fs.writeFileSync(path.resolve(__dirname, 'expected', 'relation.2453564.1.xml'), xml);
-    var expected = fs.readFileSync(path.resolve(__dirname, 'expected', 'relation.2453564.1.xml'), 'utf8').trim();
-    assert.equal(xml, expected, 'expected output xml');
-    assert.end();
-  });
-});
-
-mockOsm.test('[index.full] (creationTime) version not included', function(assert) {
-  full(mockOsm.baseUrl, 'relation', 2453564, { creationTime: true }, function(err, xml, timestamp) {
-    assert.ifError(err, 'success');
-    assert.equal(timestamp, 1349406008000, 'expected timestamp');
-    var expected = fs.readFileSync(path.resolve(__dirname, 'expected', 'relation.2453564.1.xml'), 'utf8').trim();
-    assert.equal(xml, expected, 'expected output xml');
-    assert.end();
-  });
-});
-
-mockOsm.test('[index.full] (creationTime) element does not exist', function(assert) {
-  full(mockOsm.baseUrl, 'way', 1, { version: 2, creationTime: true }, function(err) {
+mockOsm.test('[index.full] element does not exist', function(assert) {
+  full(mockOsm.baseUrl, 'way', 1, 2, function(err) {
     assert.equal(err.statusCode, 404, 'expected statusCode');
     assert.end();
   });
 });
 
-mockOsm.test('[index.full] (creationTime) failure to parse parent xml', function(assert) {
-  full(mockOsm.baseUrl, 'node', 1, { version: 3, creationTime: true }, function(err) {
+mockOsm.test('[index.full] failure to parse parent xml', function(assert) {
+  full(mockOsm.baseUrl, 'node', 1, 3, function(err) {
     assert.equal(err.statusCode, 500, 'expected statusCode');
     assert.end();
   });
 });
 
-mockOsm.test('[index.full] (creationTime) failure to parse child xml', function(assert) {
-  full(mockOsm.baseUrl, 'way', 999, { version: 1, creationTime: true }, function(err) {
-    assert.equal(err.statusCode, 500, 'expected statusCode');
-    assert.end();
-  });
-});
-
-mockOsm.test('[index.full] (creationTime) failure to parse history xml', function(assert) {
-  full(mockOsm.baseUrl, 'way', 998, { version: 1, creationTime: true }, function(err) {
-    assert.equal(err.statusCode, 500, 'expected statusCode');
-    assert.end();
-  });
-});
-
-mockOsm.test('[index.full] (creationTime) nested ref timestamps relative to top-level parent', function(assert) {
-  full(mockOsm.baseUrl, 'relation', 1234, { version: 1, creationTime: true }, function(err, xml, timestamp) {
-    assert.ifError(err, 'success');
-    assert.equal(timestamp, 1349406000000, 'expected timestamp');
-    var expected = fs.readFileSync(path.resolve(__dirname, 'expected', 'relation.1234.1.creation.xml'), 'utf8').trim();
-    assert.equal(xml, expected, 'expected output xml');
-    assert.end();
-  });
-});
-
-mockOsm.test('[index.full] (creationTime) no duplicate items in closed way', function(assert) {
-  full(mockOsm.baseUrl, 'way', 362662527, { version: 1, creationTime: true }, function(err, xml, timestamp) {
-    assert.ifError(err, 'success');
-    assert.equal(timestamp, 1438032946000, 'expected timestamp');
-    var expected = fs.readFileSync(path.resolve(__dirname, 'expected', 'way.362662527.1.xml'), 'utf8').trim();
-    assert.equal(xml, expected, 'expected output xml');
-    assert.end();
-  });
-});
-
-mockOsm.test('[index.full] (creationTime) gets all xml', function(assert) {
-  full(mockOsm.baseUrl, 'relation', 2453564, { version: 1, creationTime: true }, function(err, xml, timestamp) {
-    assert.ifError(err, 'success');
-    assert.equal(timestamp, 1349406008000, 'expected timestamp');
-    fs.writeFileSync(path.resolve(__dirname, 'expected', 'relation.2453564.1.xml'), xml);
-    var expected = fs.readFileSync(path.resolve(__dirname, 'expected', 'relation.2453564.1.xml'), 'utf8').trim();
-    assert.equal(xml, expected, 'expected output xml');
-    assert.end();
-  });
-});
-
-mockOsm.test('[index.full] (creationTime) version not included', function(assert) {
-  full(mockOsm.baseUrl, 'relation', 2453564, { creationTime: true }, function(err, xml, timestamp) {
-    assert.ifError(err, 'success');
-    assert.equal(timestamp, 1349406008000, 'expected timestamp');
-    var expected = fs.readFileSync(path.resolve(__dirname, 'expected', 'relation.2453564.1.xml'), 'utf8').trim();
-    assert.equal(xml, expected, 'expected output xml');
-    assert.end();
-  });
-});
-
-mockOsm.test('[index.full] (finalTime) element does not exist', function(assert) {
-  full(mockOsm.baseUrl, 'way', 1, { version: 2 }, function(err) {
-    assert.equal(err.statusCode, 404, 'expected statusCode');
-    assert.end();
-  });
-});
-
-mockOsm.test('[index.full] (finalTime) failure to parse parent xml', function(assert) {
-  full(mockOsm.baseUrl, 'node', 1, { version: 3 }, function(err) {
-    assert.equal(err.statusCode, 500, 'expected statusCode');
-    assert.end();
-  });
-});
-
-mockOsm.test('[index.full] (finalTime) failure to parse child xml', function(assert) {
+mockOsm.test('[index.full] failure to parse child xml', function(assert) {
   full(mockOsm.baseUrl, 'way', 999, function(err) {
     assert.equal(err.statusCode, 500, 'expected statusCode');
     assert.end();
   });
 });
 
-mockOsm.test('[index.full] (finalTime) failure to parse history xml', function(assert) {
-  full(mockOsm.baseUrl, 'way', 998, { version: 1 }, function(err) {
+mockOsm.test('[index.full] failure to parse history xml', function(assert) {
+  full(mockOsm.baseUrl, 'way', 998, 1, function(err) {
     assert.equal(err.statusCode, 500, 'expected statusCode');
     assert.end();
   });
 });
 
-mockOsm.test('[index.full] (finalTime) nested ref timestamps relative to top-level parent', function(assert) {
-  full(mockOsm.baseUrl, 'relation', 1234, { version: 1 }, function(err, xml, timestamp) {
+mockOsm.test('[index.full] nested ref timestamps relative to top-level parent', function(assert) {
+  full(mockOsm.baseUrl, 'relation', 1234, 1, function(err, xml, timestamp) {
     assert.ifError(err, 'success');
     assert.equal(timestamp, 1349416799999, 'expected timestamp');
     var expected = fs.readFileSync(path.resolve(__dirname, 'expected', 'relation.1234.1.final.xml'), 'utf8').trim();
@@ -132,15 +43,15 @@ mockOsm.test('[index.full] (finalTime) nested ref timestamps relative to top-lev
   });
 });
 
-mockOsm.test('[index.full] (finalTime) history endpoint failure', function(assert) {
-  full(mockOsm.baseUrl, 'relation', 12345, { version: 1 }, function(err) {
+mockOsm.test('[index.full] history endpoint failure', function(assert) {
+  full(mockOsm.baseUrl, 'relation', 12345, 1, function(err) {
     assert.equal(err.statusCode, 500, 'expected statusCode');
     assert.end();
   });
 });
 
-mockOsm.test('[index.full] (finalTime) no duplicate items in closed way', function(assert) {
-  full(mockOsm.baseUrl, 'way', 362662527, { version: 1 }, function(err, xml, timestamp) {
+mockOsm.test('[index.full] no duplicate items in closed way', function(assert) {
+  full(mockOsm.baseUrl, 'way', 362662527, 1, function(err, xml, timestamp) {
     assert.ifError(err, 'success');
     assert.ok(Date.now() - timestamp < 100, 'expected timestamp');
     var expected = fs.readFileSync(path.resolve(__dirname, 'expected', 'way.362662527.1.xml'), 'utf8').trim();
@@ -154,6 +65,29 @@ mockOsm.test('[index.shallow]', function(assert) {
     assert.ifError(err, 'success');
     var expected = fs.readFileSync(path.resolve(__dirname, 'expected', 'relation.2453564.1.xml'), 'utf8').trim();
     assert.equal(xml, expected, 'expected output xml');
+    assert.end();
+  });
+});
+
+mockOsm.test('[index.at]', function(assert) {
+  at(mockOsm.baseUrl, 'relation', 1234, 1349407800000, function(err, xml) {
+    assert.ifError(err, 'success');
+    var expected = fs.readFileSync(path.resolve(__dirname, 'expected', 'relation.1234.1.creation.xml'), 'utf8').trim();
+    assert.equal(xml, expected, 'expected output xml');
+    assert.end();
+  });
+});
+
+mockOsm.test('[index.at] element does not exist', function(assert) {
+  at(mockOsm.baseUrl, 'way', 1, 1349407800000, function(err) {
+    assert.equal(err.statusCode, 404, 'expected statusCode');
+    assert.end();
+  });
+});
+
+mockOsm.test('[index.at] element did not exist at requested time', function(assert) {
+  at(mockOsm.baseUrl, 'relation', 1234, 1349405000000, function(err) {
+    assert.equal(err.statusCode, 500, 'expected statusCode');
     assert.end();
   });
 });


### PR DESCRIPTION
Adds a mechanism to request the state of a feature and its references at a specific timestamp. This replaces the pre-existing distinction between resolving references at a version's creation time or final state (which was too confusing anyway).
