### PR TITLE
Performance improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
   - "0.10"
+  - "4"
 sudo: false

--- a/bin/osm-fetch.js
+++ b/bin/osm-fetch.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+require('https').globalAgent.keepAlive = true;
 var fetch = require('..');
 var args = require('minimist')(process.argv.slice(2), {
   boolean: ['s', 'shallow']

--- a/lib/osm.js
+++ b/lib/osm.js
@@ -3,7 +3,7 @@ var parse = require('./parse');
 
 module.exports = function(baseUrl) {
   var cache = {};
-  
+
   function get(uri, callback) {
     if (cache[uri]) return callback(null, cache[uri]);
 
@@ -17,6 +17,11 @@ module.exports = function(baseUrl) {
       if (err) {
         err.statusCode = 500;
         return callback(err);
+      }
+
+      var retryable = res.statusCode >= 500 || res.statusCode === 408;
+      if (retries < 3 && retryable) {
+        return setTimeout(request, Math.pow(50 * Math.random(), ++retries), uri, response);
       }
 
       if (res.statusCode !== 200) {

--- a/lib/osm.js
+++ b/lib/osm.js
@@ -1,24 +1,37 @@
 var request = require('request');
 var parse = require('./parse');
 
-function get(uri, callback) {
-  request(uri, function(err, res, body) {
-    if (err) {
-      err.statusCode = 500;
-      return callback(err);
-    }
-
-    if (res.statusCode !== 200) {
-      err = new Error(body);
-      err.statusCode = res.statusCode;
-      return callback(err);
-    }
-
-    callback(null, body);
-  });
-}
-
 module.exports = function(baseUrl) {
+  var cache = {};
+  
+  function get(uri, callback) {
+    if (cache[uri]) return callback(null, cache[uri]);
+
+    var retries = 0;
+
+    function response(err, res, body) {
+      if (err && retries < 3) {
+        return setTimeout(request, Math.pow(50 * Math.random(), ++retries), uri, response);
+      }
+
+      if (err) {
+        err.statusCode = 500;
+        return callback(err);
+      }
+
+      if (res.statusCode !== 200) {
+        err = new Error(body);
+        err.statusCode = res.statusCode;
+        return callback(err);
+      }
+
+      cache[uri] = body;
+      callback(null, body);
+    }
+
+    request(uri, response);
+  }
+
   return {
     fetch: function(type, id, version, callback) {
       var uri = [baseUrl, 'api/0.6', type, id];

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "minimist": "^1.2.0",
-    "queue-async": "^1.0.7",
+    "queue-async": "1.0.7",
     "request": "^2.67.0",
     "sax": "^1.1.4",
     "xml2js": "^0.4.15"

--- a/test/mock-osm.js
+++ b/test/mock-osm.js
@@ -32,6 +32,11 @@ function osm(req, res) {
     return res.socket.destroy();
   }
 
+  if (type === 'node' && id === 987654) {
+    res.statusCode = 408;
+    return res.end();
+  }
+
   var re = new RegExp('^' + [type, id].join('.') + '.+\.xml$');
   var xmls = fixtures.filter(function(filename) {
     return re.test(filename);

--- a/test/mock-osm.js
+++ b/test/mock-osm.js
@@ -6,7 +6,7 @@ var tape = require('tape');
 
 var fixtures = fs.readdirSync(path.join(__dirname, 'fixtures'));
 
-var server = http.createServer(function(req, res) {
+function osm(req, res) {
   if (req.method !== 'GET') {
     res.statusCode = 400;
     return res.end();
@@ -70,12 +70,19 @@ var server = http.createServer(function(req, res) {
   if (process.env.DEBUG) console.log('%s %s', req.url, 500);
   res.statusCode = 500;
   res.end();
-});
+}
 
 module.exports = {
   baseUrl: 'http://localhost:20009',
   test: function(name, callback) {
     tape(name, function(assert) {
+      var context = { requests: 0 };
+
+      var server = http.createServer(function(req, res) {
+        context.requests++;
+        osm(req, res);
+      });
+
       server.listen(20009, function(err) {
         if (err) throw err;
 
@@ -89,7 +96,7 @@ module.exports = {
           });
         };
 
-        callback(assert);
+        callback.call(context, assert);
       });
     });
   }

--- a/test/osm.test.js
+++ b/test/osm.test.js
@@ -41,6 +41,15 @@ mockOsm.test('[fetch] returns 404 for non-existent element', function(assert) {
   });
 });
 
+mockOsm.test('[fetch] returns 408 for request timeout', function(assert) {
+  var client = osm(mockOsm.baseUrl);
+  client.fetch('node', 987654, 3, function(err, data) {
+    assert.equal(err.statusCode, 408, 'expected statusCode');
+    assert.notOk(data, 'no data returned');
+    assert.end();
+  });
+});
+
 mockOsm.test('[fetch] get caching', function(assert) {
   var context = this;
   var client = osm(mockOsm.baseUrl);

--- a/test/osm.test.js
+++ b/test/osm.test.js
@@ -41,6 +41,19 @@ mockOsm.test('[fetch] returns 404 for non-existent element', function(assert) {
   });
 });
 
+mockOsm.test('[fetch] get caching', function(assert) {
+  var context = this;
+  var client = osm(mockOsm.baseUrl);
+  client.fetch('node', 3668963800, 3, function(err) {
+    if (err) return assert.end(err);
+    client.fetch('node', 3668963800, 3, function(err) {
+      if (err) return assert.end(err);
+      assert.equal(context.requests, 1, 'cached requests');
+      assert.end();
+    });
+  });
+});
+
 mockOsm.test('[fetchVersionAt] correct version for a specified timestamp', function(assert) {
   var client = osm(mockOsm.baseUrl);
   client.fetchVersionAt('node', 3668963800, 1451531387000, function(err, data) {


### PR DESCRIPTION
- use keep alive agent (node 0.12+)
- limit the async queue depth (infinity is never a good idea)
- 3 retries on networking failures, exponential backoff (things always go wrong)
- read cache for shared objects (why ask for the same thing twice?)

@ian29 this reduced the time taken to fetch a certain relation!4237279 from never or next to forever to a little over a minute.
