### PR TITLE
nodes don't have a /full endpoint

### DIFF
--- a/lib/osm.js
+++ b/lib/osm.js
@@ -98,7 +98,8 @@ module.exports = function(baseUrl) {
     },
 
     fetchShallow: function(type, id, callback) {
-      var uri = [baseUrl, 'api/0.6', type, id, 'full'];
+      var uri = [baseUrl, 'api/0.6', type, id];
+      if (type !== 'node') uri.push('full');
       get(uri.join('/'), callback);
     }
   };


### PR DESCRIPTION
Fixes `.shallow` for nodes (which is a silly thing to ask for, but yolo).
